### PR TITLE
Run extract-stats as part of action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,18 +20,18 @@ jobs:
             path: gh-testing-research
       - name: Run action
         # It will fail on sending data to honeycomb because we're providing a 
-        # dummy api key, but the log-stats file should be created if it completed 
+        # dummy api key, but the extracted_stats file should be created if it completed 
         # the rest of the steps
         uses: ./
         continue-on-error: true
         with:
             directory: gh-testing-research
-      - name: Assert log-stats file created
+      - name: Assert extracted stats file created
         run: |
-            if test -f gh-testing-research/metadata/log_stats.json; then
-                echo "log_stats.json file exists"
+            if test -f gh-testing-research/metadata/extracted_stats.json; then
+                echo "extracted_stats.json file exists"
             else
-                echo "Action should have created log_stats.json file"
+                echo "Action should have created extracted_stats.json file"
                 exit 1
             fi
   lint-action:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,11 +19,7 @@ jobs:
             repository: opensafely/gh-testing-research
             path: gh-testing-research
       - name: Run action
-        # It will fail on sending data to honeycomb because we're providing a 
-        # dummy api key, but the extracted_stats file should be created if it completed 
-        # the rest of the steps
         uses: ./
-        continue-on-error: true
         with:
             directory: gh-testing-research
       - name: Assert extracted stats file created

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,7 @@ on: [push]
 env:
  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  STATA_LICENSE: ${{ secrets.STATA_LICENSE }}
+ HONEYCOMB_API_KEY: dummy-key
 
 jobs:
   test-action:
@@ -18,15 +19,19 @@ jobs:
             repository: opensafely/gh-testing-research
             path: gh-testing-research
       - name: Run action
+        # It will fail on sending data to honeycomb because we're providing a 
+        # dummy api key, but the log-stats file should be created if it completed 
+        # the rest of the steps
         uses: ./
+        continue-on-error: true
         with:
             directory: gh-testing-research
       - name: Assert log-stats file created
         run: |
             if test -f gh-testing-research/metadata/log_stats.json; then
-                echo "log-stats.json file exists"
+                echo "log_stats.json file exists"
             else
-                echo "Action should have created log-stats.json file"
+                echo "Action should have created log_stats.json file"
                 exit 1
             fi
   lint-action:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,14 @@ jobs:
         uses: ./
         with:
             directory: gh-testing-research
-
+      - name: Assert log-stats file created
+        run: |
+            if test -f gh-testing-research/metadata/log_stats.json; then
+                echo "log-stats.json file exists"
+            else
+                echo "Action should have created log-stats.json file"
+                exit 1
+            fi
   lint-action:
     runs-on: ubuntu-20.04
     name: Lint action

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ docker tag honeytail ghcr.io/opensafely-core/honeytail:latest
 docker push ghcr.io/opensafely-core/honeytail:latest
 ```
 
+To build a dev image that will push to a test dataset (`research-action-test`):
+```
+just docker/build-dev
+just docker/run <path/to/log/file> <HONEYCOMB_API_KEY>
+```
+
 ## Tests
 
 Github actions are very difficult to test locally. The approach we use is to a)

--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ jobs:
 The [research-template][2] repo includes such a [workflow file][3] already.
 
 
+## Honeytail
+
+The Action also extracts stats from the test run and sends them to our [Honeycomb ](https://www.honeycomb.io/) `research-action` dataset, via [honeytail](https://github.com/honeycombio/honeytail).  The action will run using the latest honeytail docker image.  If you need to update the docker image, run:
+
+```
+just docker/build
+docker tag honeytail ghcr.io/opensafely-core/honeytail:latest
+docker push ghcr.io/opensafely-core/honeytail:latest
+```
+
 ## Tests
 
 Github actions are very difficult to test locally. The approach we use is to a)

--- a/action.yml
+++ b/action.yml
@@ -61,10 +61,7 @@ runs:
       shell: bash
       run: opensafely extract-stats
       working-directory: ${{ inputs.directory }}
-    - name: Build honeycomb
-      shell: bash
-      run: just docker/build
     - name: Send extracted stats to honeycomb
       shell: bash
       run: |
-        just docker/run $GITHUB_ACTION_PATH/${{ inputs.directory }}/metadata/extracted_stats.json $HONEYCOMB_API_KEY
+        just docker/run_image $GITHUB_ACTION_PATH/${{ inputs.directory }}/metadata/extracted_stats.json $HONEYCOMB_API_KEY

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,7 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - uses: extractions/setup-just@aa5d15c144db4585980a44ebfdd2cf337c4f14cb  # v1.4.0
     - name: Install opensafely
       shell: bash
       # run: |
@@ -60,3 +61,10 @@ runs:
       shell: bash
       run: opensafely log-stats
       working-directory: ${{ inputs.directory }}
+    - name: Build honeycomb
+      shell: bash
+      run: just docker/build
+    - name: Send log-stats to honeycomb
+      shell: bash
+      run: |
+        just docker/run $GITHUB_ACTION_PATH/${{ inputs.directory }}/metadata/log_stats.json $HONEYCOMB_API_KEY

--- a/action.yml
+++ b/action.yml
@@ -59,12 +59,12 @@ runs:
       run: opensafely run run_all --continue-on-error --timestamps --format-output-for-github
     - name: Parse stats logs
       shell: bash
-      run: opensafely log-stats
+      run: opensafely extract-stats
       working-directory: ${{ inputs.directory }}
     - name: Build honeycomb
       shell: bash
       run: just docker/build
-    - name: Send log-stats to honeycomb
+    - name: Send extracted stats to honeycomb
       shell: bash
       run: |
-        just docker/run $GITHUB_ACTION_PATH/${{ inputs.directory }}/metadata/log_stats.json $HONEYCOMB_API_KEY
+        just docker/run $GITHUB_ACTION_PATH/${{ inputs.directory }}/metadata/extracted_stats.json $HONEYCOMB_API_KEY

--- a/action.yml
+++ b/action.yml
@@ -18,9 +18,11 @@ runs:
   steps:
     - name: Install opensafely
       shell: bash
+      # run: |
+      #     python3 -m pip install --quiet --upgrade opensafely
+      #     opensafely --version
       run: |
-          python3 -m pip install --quiet --upgrade opensafely
-          opensafely --version
+        python3 -m pip install git+https://github.com/opensafely-core/opensafely-cli.git@log-stats
     - name: Check codelists
       shell: bash
       working-directory: ${{ inputs.directory }}
@@ -54,3 +56,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.directory }}
       run: opensafely run run_all --continue-on-error --timestamps --format-output-for-github
+    - name: Parse stats logs
+      shell: bash
+      run: opensafely log-stats
+      working-directory: ${{ inputs.directory }}

--- a/action.yml
+++ b/action.yml
@@ -19,11 +19,9 @@ runs:
     - uses: extractions/setup-just@aa5d15c144db4585980a44ebfdd2cf337c4f14cb  # v1.4.0
     - name: Install opensafely
       shell: bash
-      # run: |
-      #     python3 -m pip install --quiet --upgrade opensafely
-      #     opensafely --version
       run: |
-        python3 -m pip install git+https://github.com/opensafely-core/opensafely-cli.git@log-stats
+          python3 -m pip install --quiet --upgrade opensafely
+          opensafely --version
     - name: Check codelists
       shell: bash
       working-directory: ${{ inputs.directory }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,35 @@
+# This builds the binary inside an Alpine Linux container, which is small
+# hadolint ignore=DL3007
+FROM ghcr.io/opensafely-core/base-docker:latest as base
+
+# we are going to use an apt cache on the host, so disable the default debian
+# docker clean up that deletes that cache on every apt install
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+
+# install any additional system dependencies
+COPY docker/dependencies.txt /tmp/dependencies.txt
+RUN --mount=type=cache,target=/var/cache/apt \
+    /root/docker-apt-install.sh /tmp/dependencies.txt
+ 
+WORKDIR /
+RUN wget -q -O honeytail https://honeycomb.io/download/honeytail/v1.6.0/honeytail-linux-amd64 && \
+      echo 'ade48161cbf79173ed7e2e476a53c45d1c9962c3332f0774f8dca67a067e1e12  honeytail' | sha256sum -c && \
+      chmod 755 ./honeytail
+
+ENV HONEYCOMB_WRITE_KEY NULL
+# The target log file is mounted to this location when the container is run
+ENV LOG_FILENAME /src/log_file.json
+
+CMD [ "/bin/sh", "-c", "./honeytail \
+            --parser json \
+            --writekey $HONEYCOMB_WRITE_KEY \
+            --file $LOG_FILENAME \
+            --dataset 'research-action' \
+            --backfill" ]
+
+# finally, tag with build information. These will change regularly, therefore
+# we do them as the last action.
+ARG BUILD_DATE=unknown
+LABEL org.opencontainers.image.created=$BUILD_DATE
+ARG GITREF=unknown
+LABEL org.opencontainers.image.revision=$GITREF

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,7 +24,7 @@ CMD [ "/bin/sh", "-c", "./honeytail \
             --parser json \
             --writekey $HONEYCOMB_WRITE_KEY \
             --file $LOG_FILENAME \
-            --dataset 'research-action' \
+            --dataset $DATASET \
             --backfill" ]
 
 # finally, tag with build information. These will change regularly, therefore

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,8 @@ ENV HONEYCOMB_WRITE_KEY NULL
 # The target log file is mounted to this location when the container is run
 ENV LOG_FILENAME /src/log_file.json
 
-CMD [ "/bin/sh", "-c", "./honeytail \
+CMD [ "/bin/sh", "-c", \
+            "[ $HONEYCOMB_WRITE_KEY = dummy-key ] && echo 'Dummy key found, nothing to do here.' || ./honeytail \
             --parser json \
             --writekey $HONEYCOMB_WRITE_KEY \
             --file $LOG_FILENAME \

--- a/docker/dependencies.txt
+++ b/docker/dependencies.txt
@@ -1,0 +1,3 @@
+# list ubuntu packages needed in production, one per line
+golang-go
+wget

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,0 +1,21 @@
+# note: we do not run prod service with docker-compose, we use it just for
+# configuring the production build
+services:
+  honeytail:
+    # image name, both locally and public
+    image: honeytail
+    build:
+      context: ..
+      # path relative to context
+      dockerfile: docker/Dockerfile
+      # should speed up the build in CI, where we have a cold cache
+      cache_from:  # should speed up the build in CI, where we have a cold cache
+        - ghcr.io/opensafely-core/base-docker
+        - ghcr.io/opensafely-core/honeytail
+      args:
+        # this makes the image work for later cache_from: usage
+        - BUILDKIT_INLINE_CACHE=1
+    environment:
+      - HONEYCOMB_WRITE_KEY=${HONEYCOMB_WRITE_KEY}
+    volumes:  
+      - $LOG_FILE_PATH:/src/log_file.json

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -17,5 +17,13 @@ services:
         - BUILDKIT_INLINE_CACHE=1
     environment:
       - HONEYCOMB_WRITE_KEY=${HONEYCOMB_WRITE_KEY}
+      - DATASET=${DATASET:-research-action}
     volumes:  
       - $LOG_FILE_PATH:/src/log_file.json
+
+  honeytail-dev:
+    image: honeytail-dev
+    extends:
+      service: honeytail
+    environment:
+    - DATASET=research-action-test

--- a/docker/justfile
+++ b/docker/justfile
@@ -1,0 +1,29 @@
+export DOCKER_USERID := `id -u`
+export DOCKER_GROUPID := `id -g`
+
+# Load .env files by default
+set dotenv-load := true
+
+# enable modern docker build features
+export DOCKER_BUILDKIT := "1"
+export COMPOSE_DOCKER_CLI_BUILD := "1"
+
+export BIN := "/opt/venv/bin"
+
+build:
+    #!/usr/bin/env bash
+
+    # set build args for prod builds
+    export BUILD_DATE=$(date -u +'%y-%m-%dT%H:%M:%SZ')
+    export GITREF=$(git rev-parse --short HEAD)
+    # build the thing
+    docker-compose build --pull
+
+run log_file api_key:
+    #!/usr/bin/env bash
+
+    export LOG_FILE_PATH={{ log_file }}
+    export HONEYCOMB_WRITE_KEY={{ api_key }}
+    echo "setting LOG_FILE_PATH=$LOG_FILE_PATH"
+    # build the thing
+    docker-compose run --rm honeytail

--- a/docker/justfile
+++ b/docker/justfile
@@ -17,18 +17,25 @@ build:
     export BUILD_DATE=$(date -u +'%y-%m-%dT%H:%M:%SZ')
     export GITREF=$(git rev-parse --short HEAD)
     # build the thing
-    docker-compose build --pull
+    docker-compose build --pull honeytail
 
-# Run honeytail service (build if necessary) using docker-compose
-run log_file api_key:
+
+build-dev:
     #!/usr/bin/env bash
+    docker-compose build --pull honeytail-dev
 
+
+# Run honeytail dev service (build if necessary) using docker-compose
+# This sends to a test dataset
+run log_file api_key image="honeytail-dev":
+    #!/usr/bin/env bash
     export LOG_FILE_PATH={{ log_file }}
     export HONEYCOMB_WRITE_KEY={{ api_key }}
     echo "setting LOG_FILE_PATH=$LOG_FILE_PATH"
-    docker-compose run --rm honeytail
+    docker-compose run --rm {{ image }}
 
 # Run honeytail using latest image
+# This sends to the prod dataset
 run_image log_file api_key:
     #!/usr/bin/env bash
     echo "Using log file {{ log_file }}"

--- a/docker/justfile
+++ b/docker/justfile
@@ -19,11 +19,20 @@ build:
     # build the thing
     docker-compose build --pull
 
+# Run honeytail service (build if necessary) using docker-compose
 run log_file api_key:
     #!/usr/bin/env bash
 
     export LOG_FILE_PATH={{ log_file }}
     export HONEYCOMB_WRITE_KEY={{ api_key }}
     echo "setting LOG_FILE_PATH=$LOG_FILE_PATH"
-    # build the thing
     docker-compose run --rm honeytail
+
+# Run honeytail using latest image
+run_image log_file api_key:
+    #!/usr/bin/env bash
+    echo "Using log file {{ log_file }}"
+    docker run --rm \
+    --volume {{ log_file }}:/src/log_file.json \
+    --env HONEYCOMB_WRITE_KEY={{ api_key }} \
+    ghcr.io/opensafely-core/honeytail:latest

--- a/docker/justfile
+++ b/docker/justfile
@@ -39,7 +39,7 @@ run log_file api_key image="honeytail-dev":
 run_image log_file api_key:
     #!/usr/bin/env bash
     echo "Using log file {{ log_file }}"
-    docker run --rm \
+    docker run --pull=missing --rm \
     --volume {{ log_file }}:/src/log_file.json \
     --env HONEYCOMB_WRITE_KEY={{ api_key }} \
     ghcr.io/opensafely-core/honeytail:latest


### PR DESCRIPTION
After running the `opensafely run run_all` command, it also runs `opensafely extract-stats` to extract the stats logs from the just completed actions.  Then runs the honeytail docker image and sends the stats logs to honeycomb (still requires access to a `HONEYCOMB_API_KEY` variable in order to work). 