### PR TITLE
Run honeytail without just or access to docker folder

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,6 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: extractions/setup-just@aa5d15c144db4585980a44ebfdd2cf337c4f14cb  # v1.4.0
     - name: Install opensafely
       shell: bash
       run: |
@@ -64,4 +63,7 @@ runs:
       if: ${{ env.HONEYCOMB_API_KEY }}
       shell: bash
       run: |
-        just docker/run_image $GITHUB_ACTION_PATH/${{ inputs.directory }}/metadata/extracted_stats.json $HONEYCOMB_API_KEY
+        docker run --pull=missing --rm \
+        --volume $GITHUB_ACTION_PATH/${{ inputs.directory }}/metadata/extracted_stats.json:/src/log_file.json \
+        --env HONEYCOMB_WRITE_KEY=$HONEYCOMB_API_KEY \
+        ghcr.io/opensafely-core/honeytail:latest

--- a/action.yml
+++ b/action.yml
@@ -66,4 +66,5 @@ runs:
         docker run --pull=missing --rm \
         --volume $GITHUB_ACTION_PATH/${{ inputs.directory }}/metadata/extracted_stats.json:/src/log_file.json \
         --env HONEYCOMB_WRITE_KEY=$HONEYCOMB_API_KEY \
+        --env DATASET=research-action \
         ghcr.io/opensafely-core/honeytail:latest

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,6 +17,7 @@ RUN wget -q -O honeytail https://honeycomb.io/download/honeytail/v1.6.0/honeytai
       chmod 755 ./honeytail
 
 ENV HONEYCOMB_WRITE_KEY NULL
+ENV DATASET NULL
 # The target log file is mounted to this location when the container is run
 ENV LOG_FILENAME /src/log_file.json
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -26,4 +26,4 @@ services:
     extends:
       service: honeytail
     environment:
-    - DATASET=research-action-test
+      - DATASET=research-action-test

--- a/docker/justfile
+++ b/docker/justfile
@@ -42,4 +42,5 @@ run_image log_file api_key:
     docker run --pull=missing --rm \
     --volume {{ log_file }}:/src/log_file.json \
     --env HONEYCOMB_WRITE_KEY={{ api_key }} \
+    --env DATASET=research-action \
     ghcr.io/opensafely-core/honeytail:latest


### PR DESCRIPTION
Study repos using the research template won't have access to the docker folder, so we need to run the image directly, not via just

https://github.com/opensafely/research-template/runs/6309659194?check_suite_focus=true