### PR TITLE
Allow specifying a subset of actions to run in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,38 @@ jobs:
                 echo "Action should have created extracted_stats.json file"
                 exit 1
             fi
+  test-single-action:
+    runs-on: ubuntu-20.04
+    name: Test single action
+    env:
+      HONEYCOMB_API_KEY: dummy-key
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Checkout gh-testing-research
+        uses: actions/checkout@v4
+        with:
+            repository: opensafely/gh-testing-research
+            path: gh-testing-research
+      - name: Run action
+        uses: ./
+        with:
+            directory: gh-testing-research
+            actions: generate_dataset
+      - name: Assert dataset.csv file created but not model.log file
+        run: |
+            if test -f gh-testing-research/output/dataset.csv; then
+                echo "output/dataset.csv file exists"
+            else
+                echo "Action should have created output/dataset.csv"
+                exit 1
+            fi
+            if test -f gh-testing-research/logs/model.log; then
+                echo "Action should not have created logs/model.log file"
+                exit 1
+            else
+                echo "logs/model.log file does not exist"
+            fi
   test-no-honeycomb-api-key:
     runs-on: ubuntu-20.04
     name: Test no Honeycomb API key

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: "@names of users who should be notified on dataset failure"
     required: false
     default: "@amirmehrkar @JulietUnderdown1 @LiamHart-hub @alexwalkerepi"
+  actions:
+    description: "Names of project actions to run during tests (default 'run_all')"
+    required: false
+    default: "run_all"
 
 outputs:
   issue:
@@ -56,7 +60,7 @@ runs:
     - name: Run project
       shell: bash
       working-directory: ${{ inputs.directory }}
-      run: opensafely run run_all --continue-on-error --timestamps --format-output-for-github
+      run: opensafely run ${{ inputs.actions }} --continue-on-error --timestamps --format-output-for-github
     - name: Parse stats logs
       if: ${{ env.HONEYCOMB_API_KEY }}
       shell: bash


### PR DESCRIPTION
Supports running just a subset of pipeline actions rather than `run_all` e.g.:
```yaml
 - name: Test that the project is runnable
   uses: opensafely-core/research-action@v2
   with:
     actions: test_action_1 test_action_2 test_action_3
```

Docs added in:
 * https://github.com/opensafely/documentation/pull/1745

Closes #112